### PR TITLE
Simplify chose for hard-coded choices

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -149,6 +149,7 @@ await expect(
 
 Notice: because we need to keep the ordering, the pipeline in the individual cases will only
 process one item a time, so if you call [toArray](#toArray) you will get an array of that item.
+But if you hard-code the choice as a string, it doesn't have this limitation.
 
 ## delay
 

--- a/packages/core/src/chose.js
+++ b/packages/core/src/chose.js
@@ -5,8 +5,11 @@ const forEach = require("./forEach");
 const channelStep = require("./channelStep");
 
 const chose = (caseOrSelector, cases) => {
-  const selector =
-    typeof caseOrSelector === "string" ? () => caseOrSelector : caseOrSelector;
+  if (typeof caseOrSelector === "string") {
+    return cases[caseOrSelector];
+  }
+
+  const selector = caseOrSelector;
 
   return channelStep((input, errors) => {
     const output = chan();


### PR DESCRIPTION
If you hard-code a choice, it is the same as replacing the chose with
the chosen pipeline.

This is useful for cases where you know before crating the pipeline
which choice should be taken.