### PR TITLE
Default to map instead of flatMap for plain functions in a pipeline (Major)

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -897,7 +897,7 @@ await expect(
 );
 ```
 
-Plain functions will be interpreted as [flatMap](#flatmap).
+Plain functions will be interpreted as [map](#map).
 
 ```js
 await expect(
@@ -905,6 +905,7 @@ await expect(
     emitItems("  \nHere is some text\n  with multiple lines\n   "),
     s => s.trim(),
     s => s.split(/\n/),
+    splitIterable(),
     s => s.trim(),
     (s, i) => s.replace(/^/, `${i + 1}) `)
   ),

--- a/packages/core/src/flatMap.js
+++ b/packages/core/src/flatMap.js
@@ -1,28 +1,7 @@
-const step = require("./step");
+const pipeline = require("./pipeline");
+const map = require("./map");
+const splitIterable = require("./splitIterable");
 
-const flatMap = mapper =>
-  step(async ({ take, put, CLOSED }) => {
-    let i = 0;
-    while (true) {
-      const value = await take();
-      if (value === CLOSED) break;
-
-      const result = await mapper(value, i++);
-
-      const isIterable =
-        result &&
-        typeof result !== "string" &&
-        (typeof result[Symbol.iterator] === "function" ||
-          typeof result[Symbol.asyncIterator] === "function");
-
-      if (isIterable) {
-        for await (let item of result) {
-          await put(item);
-        }
-      } else {
-        await put(result);
-      }
-    }
-  });
+const flatMap = (...args) => pipeline(map(...args), splitIterable());
 
 module.exports = flatMap;

--- a/packages/core/src/pipeline.js
+++ b/packages/core/src/pipeline.js
@@ -1,6 +1,6 @@
 const { chan, go, take, put, close, CLOSED } = require("medium");
 const channelStep = require("./channelStep");
-const flatMap = require("./flatMap");
+const map = require("./map");
 
 const pipeline = (...steps) =>
   channelStep((input, errors) => {
@@ -17,7 +17,7 @@ const pipeline = (...steps) =>
             }
 
             if (typeof stepOrChannel === "function") {
-              stepOrChannel = flatMap(stepOrChannel);
+              stepOrChannel = map(stepOrChannel);
             }
 
             channel =

--- a/packages/core/src/pipeline.spec.js
+++ b/packages/core/src/pipeline.spec.js
@@ -3,6 +3,7 @@ const expect = require("unexpected")
   .use(require("unexpected-steps"));
 const emitItems = require("./emitItems");
 const pipeline = require("./pipeline");
+const splitIterable = require("./splitIterable");
 const map = require("./map");
 const filter = require("./filter");
 
@@ -56,6 +57,7 @@ describe("pipeline", () => {
         emitItems("  \nHere is some text\n  with multiple lines\n   "),
         s => s.trim(),
         s => s.split(/\n/),
+        splitIterable(),
         s => s.trim(),
         (s, i) => s.replace(/^/, `${i + 1}) `)
       ),


### PR DESCRIPTION
I regretted to default plain functions in a pipeline to flat map, it is too magic, I'll use map instead. 

This is a breaking change, but given that I'm breaking something that was released an hour ago, it will not really break anything. 