### PR TITLE
Let functions in a pipeline be flat map

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -897,6 +897,22 @@ await expect(
 );
 ```
 
+Plain functions will be interpreted as [flatMap](#flatmap).
+
+```js
+await expect(
+  pipeline(
+    emitItems("  \nHere is some text\n  with multiple lines\n   "),
+    s => s.trim(),
+    s => s.split(/\n/),
+    s => s.trim(),
+    (s, i) => s.replace(/^/, `${i + 1}) `)
+  ),
+  "to yield items",
+  ["1) Here is some text", "2) with multiple lines"]
+);
+```
+
 ## program
 
 Runs all of the given steps until the output closes.

--- a/packages/core/src/flatMap.js
+++ b/packages/core/src/flatMap.js
@@ -1,7 +1,28 @@
-const pipeline = require("./pipeline");
-const map = require("./map");
-const splitIterable = require("./splitIterable");
+const step = require("./step");
 
-const flatMap = (...args) => pipeline(map(...args), splitIterable());
+const flatMap = mapper =>
+  step(async ({ take, put, CLOSED }) => {
+    let i = 0;
+    while (true) {
+      const value = await take();
+      if (value === CLOSED) break;
+
+      const result = await mapper(value, i++);
+
+      const isIterable =
+        result &&
+        typeof result !== "string" &&
+        (typeof result[Symbol.iterator] === "function" ||
+          typeof result[Symbol.asyncIterator] === "function");
+
+      if (isIterable) {
+        for await (let item of result) {
+          await put(item);
+        }
+      } else {
+        await put(result);
+      }
+    }
+  });
 
 module.exports = flatMap;

--- a/packages/core/src/pipeline.js
+++ b/packages/core/src/pipeline.js
@@ -1,5 +1,6 @@
 const { chan, go, take, put, close, CLOSED } = require("medium");
 const channelStep = require("./channelStep");
+const flatMap = require("./flatMap");
 
 const pipeline = (...steps) =>
   channelStep((input, errors) => {
@@ -13,6 +14,10 @@ const pipeline = (...steps) =>
           if (stepOrChannel) {
             if (!stepOrChannel.buffer && stepOrChannel.then) {
               stepOrChannel = await stepOrChannel;
+            }
+
+            if (typeof stepOrChannel === "function") {
+              stepOrChannel = flatMap(stepOrChannel);
             }
 
             channel =

--- a/packages/core/src/pipeline.spec.js
+++ b/packages/core/src/pipeline.spec.js
@@ -34,6 +34,36 @@ describe("pipeline", () => {
     );
   });
 
+  it("allows steps to be resolved async", async () => {
+    await expect(
+      pipeline(
+        emitItems(0, 1, 2, 3, 4, 5),
+        new Promise(resolve =>
+          setTimeout(() => {
+            resolve(filter(n => n % 2 === 0));
+          }, 0)
+        ),
+        map(n => n * n)
+      ),
+      "to yield items",
+      [0, 4, 16]
+    );
+  });
+
+  it("considers functions as flatMap", async () => {
+    await expect(
+      pipeline(
+        emitItems("  \nHere is some text\n  with multiple lines\n   "),
+        s => s.trim(),
+        s => s.split(/\n/),
+        s => s.trim(),
+        (s, i) => s.replace(/^/, `${i + 1}) `)
+      ),
+      "to yield items",
+      ["1) Here is some text", "2) with multiple lines"]
+    );
+  });
+
   it("skips steps that is falsy", async () => {
     await expect(
       pipeline(


### PR DESCRIPTION
Fixes #44

This will allow you to do a lot of things without importing `map` and `flatMap`. 