### PR TITLE
Change parallel to preserve output order

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -502,6 +502,8 @@ await expect(
 Run the given step with the specified concurrency. If no concurrency is
 specified, it will default to 2 times the number of CPU's available.
 
+Notice that we make sure to preserve the output order, so you can count on the output not changing order by using this step.
+
 ```js
 const { parallel } = require("@transformation/core");
 ```
@@ -518,13 +520,8 @@ await expect(
       4
     )
   ),
-  "to yield items satisfying to contain",
-  1,
-  2,
-  3,
-  4,
-  5,
-  6
+  "to yield items",
+  [6, 5, 4, 3, 2, 1]
 );
 ```
 
@@ -1685,14 +1682,8 @@ await expect(
       map(n => `${n} transformed`)
     )
   ),
-  "to yield items satisfying to contain",
-  "0 transformed",
-  1,
-  "4 transformed",
-  3,
-  "8 transformed",
-  5,
-  "12 transformed"
+  "to yield items",
+  ["0 transformed", 1, "4 transformed", 3, "8 transformed", 5, "12 transformed"]
 );
 ```
 
@@ -1711,14 +1702,8 @@ await expect(
       map(n => `${n} transformed`)
     )
   ),
-  "to yield items satisfying to contain",
-  0,
-  1,
-  4,
-  9,
-  16,
-  25,
-  36
+  "to yield items",
+  [0, 1, 4, 9, 16, 25, 36]
 );
 ```
 

--- a/packages/core/src/map.js
+++ b/packages/core/src/map.js
@@ -19,7 +19,9 @@ const map = mapper =>
             mappedValue.type === "step" &&
             typeof mappedValue.body === "function"
           ) {
-            const valueOutput = mappedValue.body(chan(), errors);
+            const valueInput = chan();
+            const valueOutput = mappedValue.body(valueInput, errors);
+            close(valueInput);
             while (true) {
               const item = await take(valueOutput);
               if (item === CLOSED) break;

--- a/packages/core/src/parallel.js
+++ b/packages/core/src/parallel.js
@@ -1,30 +1,87 @@
 const { go, take, close, chan, merge, put, CLOSED } = require("medium");
 const buffer = require("./buffer");
 const channelStep = require("./channelStep");
+const program = require("./program");
+const emitItems = require("./emitItems");
+const forEach = require("./forEach");
+const step = require("./step");
 
 const cpus =
   typeof module !== "undefined" && module.exports
     ? require("os").cpus().length
     : 4;
 
+const worker = childStep =>
+  step(async ({ take, put, CLOSED }) => {
+    while (true) {
+      const value = await take();
+      if (value === CLOSED) break;
+      const { index, data } = value;
+
+      await program(
+        emitItems(data),
+        childStep,
+        forEach(v => put({ index, data: v }))
+      );
+
+      await put({ index, data: CLOSED });
+    }
+  });
+
 const parallel = (step, concurrency = 2 * cpus) =>
   channelStep((input, errors) => {
-    const parallelErrors = chan(0);
     const outputs = [];
+    const output = chan();
+    const parallelInput = chan();
+
     for (var i = 0; i < concurrency; i += 1) {
-      outputs.push(step.body(input, parallelErrors));
+      outputs.push(worker(step).body(parallelInput, errors));
     }
 
+    const parallelOutput = buffer(concurrency).body(merge(...outputs));
+
     go(async () => {
+      let inputIndex = 0;
+
       while (true) {
-        const value = await take(parallelErrors);
+        const value = await take(input);
         if (value === CLOSED) break;
-        close(input);
-        await put(errors, value);
+        await put(parallelInput, { index: inputIndex++, data: value });
       }
+
+      close(parallelInput);
     });
 
-    return buffer(concurrency).body(merge(...outputs));
+    go(async () => {
+      let outputIndex = 0;
+      const outputValues = {};
+      const readyIndexes = {};
+
+      while (true) {
+        const value = await take(parallelOutput);
+        if (value === CLOSED) break;
+        const { index, data } = value;
+
+        outputValues[index] = outputValues[index] || [];
+
+        if (data === CLOSED) {
+          readyIndexes[index] = true;
+          while (readyIndexes[outputIndex]) {
+            for (let { data } of outputValues[outputIndex]) {
+              await put(output, data);
+            }
+            outputIndex++;
+          }
+        } else if (outputIndex === index) {
+          await put(output, data);
+        } else {
+          outputValues[index].push(value);
+        }
+      }
+      close(output);
+    });
+
+    return output;
   });
 
 module.exports = parallel;

--- a/packages/core/src/parallel.spec.js
+++ b/packages/core/src/parallel.spec.js
@@ -2,6 +2,7 @@ const expect = require("unexpected")
   .clone()
   .use(require("unexpected-steps"));
 const emitItems = require("./emitItems");
+const emitRepeat = require("./emitRepeat");
 const pipeline = require("./pipeline");
 const program = require("./program");
 const parallel = require("./parallel");
@@ -22,13 +23,8 @@ describe("parallel", () => {
             })
           )
         ),
-        "to yield items satisfying to contain",
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
+        "to yield items",
+        [6, 5, 4, 3, 2, 1]
       );
     });
   });
@@ -46,15 +42,29 @@ describe("parallel", () => {
             2
           )
         ),
-        "to yield items satisfying to contain",
-        1,
-        2,
-        3,
-        4,
-        5,
-        6
+        "to yield items",
+        [6, 5, 4, 3, 2, 1]
       );
     });
+  });
+
+  it("preserves the input order", async () => {
+    await expect(
+      pipeline(
+        emitItems(6, 5, 4, 3, 2, 1),
+        parallel(
+          pipeline(
+            n => emitRepeat(n, n),
+            forEach(async n => {
+              await sleep(Math.round(Math.random() * 30));
+            })
+          ),
+          2
+        )
+      ),
+      "to yield items",
+      [6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1]
+    );
   });
 
   describe("when the step fails", () => {
@@ -82,7 +92,7 @@ describe("parallel", () => {
         "Boom!"
       );
 
-      expect(processed, "to contain", 0, 1, 2);
+      expect(processed, "to equal", [0, 1, 2]);
     });
   });
 });

--- a/packages/unexpected-steps/index.js
+++ b/packages/unexpected-steps/index.js
@@ -42,19 +42,4 @@ module.exports = expect => {
       return expect(result, "to equal", expected);
     }
   );
-
-  expect.addAssertion(
-    "<step> to yield items satisfying <assertion>",
-    async (expect, step) => {
-      const result = await takeAll(step);
-      expect.subjectOutput = output => {
-        output
-          .jsKeyword("channel")
-          .text("(")
-          .appendInspected(result)
-          .text(")");
-      };
-      return expect.shift(result);
-    }
-  );
 };


### PR DESCRIPTION
This of cause introduces buffering, but I think this step will be much more useful if you can count on the order.