### PR TITLE
Fix empty partition when all partitions are full

### DIFF
--- a/packages/core/src/partition.js
+++ b/packages/core/src/partition.js
@@ -13,16 +13,18 @@ const partition = (size) =>
         nextBatch.push(value);
       }
 
-      const start = partitionNumber * size;
-      const end = start + size - 1;
-      partitionNumber++;
+      if (nextBatch.length > 0) {
+        const start = partitionNumber * size;
+        const end = start + size - 1;
+        partitionNumber++;
 
-      await put(
-        Group.create({
-          key: `[${start};${end}]`,
-          items: nextBatch,
-        })
-      );
+        await put(
+          Group.create({
+            key: `[${start};${end}]`,
+            items: nextBatch,
+          })
+        );
+      }
 
       if (value === CLOSED) break;
     }

--- a/packages/core/src/partition.spec.js
+++ b/packages/core/src/partition.spec.js
@@ -17,4 +17,29 @@ describe("partition", () => {
       ]
     );
   });
+
+  it("handles the case where a partiion isn't full", async () => {
+    await expect(
+      pipeline(emitItems(0, 1, 2, 3, 4, 5, 6), partition(2)),
+      "to yield items",
+      [
+        Group.create({ key: "[0;1]", items: [0, 1] }),
+        Group.create({ key: "[2;3]", items: [2, 3] }),
+        Group.create({ key: "[4;5]", items: [4, 5] }),
+        Group.create({ key: "[6;7]", items: [6] }),
+      ]
+    );
+  });
+
+  it("handles the case where all partiions is full", async () => {
+    await expect(
+      pipeline(emitItems(0, 1, 2, 3, 4, 5), partition(2)),
+      "to yield items",
+      [
+        Group.create({ key: "[0;1]", items: [0, 1] }),
+        Group.create({ key: "[2;3]", items: [2, 3] }),
+        Group.create({ key: "[4;5]", items: [4, 5] }),
+      ]
+    );
+  });
 });


### PR DESCRIPTION
This is the case that would create an empty partition at the end before.

```js
    await expect(
      pipeline(emitItems(0, 1, 2, 3, 4, 5), partition(2)),
      "to yield items",
      [
        Group.create({ key: "[0;1]", items: [0, 1] }),
        Group.create({ key: "[2;3]", items: [2, 3] }),
        Group.create({ key: "[4;5]", items: [4, 5] }),
      ]
    );
```