### PR TITLE
Don't reset uniq and uniqBy for each pipeline invocation

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -1736,6 +1736,8 @@ await expect(
 );
 ```
 
+Notice that `uniq` keep internal state from its first invocation.
+
 ## uniqBy
 
 Filters out items that is not unique by a selected value.
@@ -1793,6 +1795,8 @@ await expect(
   ]
 );
 ```
+
+Notice that `uniqBy` keep internal state from its first invocation.
 
 ## unless
 

--- a/packages/core/src/uniqBy.js
+++ b/packages/core/src/uniqBy.js
@@ -6,9 +6,9 @@ const uniqBy = (fieldOrSelector) => {
       ? (value) => value[fieldOrSelector]
       : fieldOrSelector;
 
-  return step(async ({ take, put, CLOSED }) => {
-    const seen = new Set();
+  const seen = new Set();
 
+  return step(async ({ take, put, CLOSED }) => {
     while (true) {
       const value = await take();
       if (value === CLOSED) break;

--- a/packages/core/src/uniqBy.spec.js
+++ b/packages/core/src/uniqBy.spec.js
@@ -54,7 +54,7 @@ describe("uniq", () => {
     });
   });
 
-  it("resets state for each invocation of the step", async () => {
+  it("doesn't reset state for each invocation of the step", async () => {
     const uniqByName = uniqBy(({ name }) => name);
 
     await expect(
@@ -82,15 +82,13 @@ describe("uniq", () => {
       pipeline(
         emitItems(
           { id: 0, name: "foo", count: 0 },
-          { id: 1, name: "bar", count: 1 }
+          { id: 1, name: "bar", count: 1 },
+          { id: 4, name: "quux", count: 4 }
         ),
         uniqByName
       ),
       "to yield items",
-      [
-        { id: 0, name: "foo", count: 0 },
-        { id: 1, name: "bar", count: 1 },
-      ]
+      [{ id: 4, name: "quux", count: 4 }]
     );
   });
 });


### PR DESCRIPTION
The current behavior is problematic as multiple steps invoke a sub-pipeline that is executed for each item, it is pretty surprising to see the uniqueness only apply for each item going into this sub-pipelines. I think it is better that you need to make sure to get a new invocation in each place you use uniqueness instead.

Breakage, if you reuse a uniqueness step in multiple pipelines, then you need to refactor to invoke the uniqueness step in each place:

```js
const uniqueByValue = uniqBy('value')

const a = pipeline(
  emitItems({ value: 'foo' }, { value: 'bar' }, { value: 'baz' })
  uniqueByValue,
)

const b = pipeline(
  emitItems({ value: 'foo' }, { value: 'bar' }, { value: 'baz' }),
  uniqueByValue,
)
```

Needs to become:

```js
const uniqueByValue = () => uniqBy('value')

const a = pipeline(
  emitItems({ value: 'foo' }, { value: 'bar' }, { value: 'baz' })
  uniqueByValue(),
)

const b = pipeline(
  emitItems({ value: 'foo' }, { value: 'bar' }, { value: 'baz' }),
  uniqueByValue(),
)
```
