### PR TITLE
Allow controlling the scope of uniqueness

### DIFF
--- a/packages/core/Readme.md
+++ b/packages/core/Readme.md
@@ -1736,7 +1736,12 @@ await expect(
 );
 ```
 
-Notice that `uniq` keep internal state from its first invocation.
+Notice that `uniq` keep internal state from its first invocation. You can
+change this behavior by setting the scope to `pipeline`, the default is `global`.
+
+```js
+const uniqToPipeline = uniq({ scope: "pipeline" });
+```
 
 ## uniqBy
 
@@ -1796,7 +1801,12 @@ await expect(
 );
 ```
 
-Notice that `uniqBy` keep internal state from its first invocation.
+Notice that `uniqBy` keep internal state from its first invocation. You can
+change this behavior by setting the scope to `pipeline`, the default is `global`.
+
+```js
+const uniqByName = uniqBy(({ name }) => name, { scope: "pipeline" });
+```
 
 ## unless
 

--- a/packages/core/src/uniq.js
+++ b/packages/core/src/uniq.js
@@ -1,5 +1,5 @@
 const uniqBy = require("./uniqBy");
 
-const uniq = () => uniqBy((v) => v);
+const uniq = (options) => uniqBy((v) => v, options);
 
 module.exports = uniq;

--- a/packages/core/src/uniq.spec.js
+++ b/packages/core/src/uniq.spec.js
@@ -11,4 +11,22 @@ describe("uniq", () => {
       [0, 4, 1, 2, 3, 5, 7, 6, 8, 9]
     );
   });
+
+  describe("when scope is pipeline", () => {
+    it("resets state for each invocation of the step", async () => {
+      const uniqInPipeline = uniq({ scope: "pipeline" });
+
+      await expect(
+        pipeline(emitItems(0, 1, 2, 0, 3, 2), uniqInPipeline),
+        "to yield items",
+        [0, 1, 2, 3]
+      );
+
+      await expect(
+        pipeline(emitItems(0, 1, 4), uniqInPipeline),
+        "to yield items",
+        [0, 1, 4]
+      );
+    });
+  });
 });

--- a/packages/core/src/uniqBy.js
+++ b/packages/core/src/uniqBy.js
@@ -1,6 +1,6 @@
 const step = require("./step");
 
-const uniqBy = (fieldOrSelector) => {
+const uniqBy = (fieldOrSelector, options = {}) => {
   const selector =
     typeof fieldOrSelector === "string"
       ? (value) => value[fieldOrSelector]
@@ -9,6 +9,10 @@ const uniqBy = (fieldOrSelector) => {
   const seen = new Set();
 
   return step(async ({ take, put, CLOSED }) => {
+    if (options.scope === "pipeline") {
+      seen.clear();
+    }
+
     while (true) {
       const value = await take();
       if (value === CLOSED) break;

--- a/packages/core/src/uniqBy.spec.js
+++ b/packages/core/src/uniqBy.spec.js
@@ -91,4 +91,48 @@ describe("uniq", () => {
       [{ id: 4, name: "quux", count: 4 }]
     );
   });
+
+  describe("when scope is pipeline", () => {
+    it("resets state for each invocation of the step", async () => {
+      const uniqByName = uniqBy(({ name }) => name, { scope: "pipeline" });
+
+      await expect(
+        pipeline(
+          emitItems(
+            { id: 0, name: "foo", count: 0 },
+            { id: 1, name: "bar", count: 1 },
+            { id: 2, name: "baz", count: 2 },
+            { id: 0, name: "foo", count: 3 },
+            { id: 3, name: "qux", count: 4 },
+            { id: 2, name: "baz", count: 5 }
+          ),
+          uniqByName
+        ),
+        "to yield items",
+        [
+          { id: 0, name: "foo", count: 0 },
+          { id: 1, name: "bar", count: 1 },
+          { id: 2, name: "baz", count: 2 },
+          { id: 3, name: "qux", count: 4 },
+        ]
+      );
+
+      await expect(
+        pipeline(
+          emitItems(
+            { id: 0, name: "foo", count: 0 },
+            { id: 1, name: "bar", count: 1 },
+            { id: 4, name: "quux", count: 4 }
+          ),
+          uniqByName
+        ),
+        "to yield items",
+        [
+          { id: 0, name: "foo", count: 0 },
+          { id: 1, name: "bar", count: 1 },
+          { id: 4, name: "quux", count: 4 },
+        ]
+      );
+    });
+  });
 });


### PR DESCRIPTION
It is sometimes useful to scope the uniqueness to a pipeline invocation.
You can do this by providing a scope option to `uniq` and `uniqBy`.